### PR TITLE
fix deprecated main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "generate-sourcemap",
   "version": "0.0.1",
   "description": "Generates a source map for files that were packed into a bundle.",
-  "main": "generate-sourcemap.js",
+  "main": "index.js",
   "scripts": {
     "test": "node-trap ./test/*.js"
   },


### PR DESCRIPTION
Latest LTS node (16.15.0) reports a deprecation warning related to the non-existent filename specified in package.json for "main". 

Noticed while running magepack, which uses this library:

`(node:1822722) [DEP0128] DeprecationWarning: Invalid 'main' field in '/usr/lib/node_modules/magepack/node_modules/generate-sourcemap/package.json' of 'generate-sourcemap.js'. Please either fix that or report it to the module author
(Use 'node --trace-deprecation ...' to show where the warning was created)`